### PR TITLE
BAU: Fixes deployments notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,9 @@ jobs:
         type: string
     steps:
       - checkout
+      - run:
+          name: Add curl
+          command: apk --no-cache add curl jq
       - attach_workspace:
           at: .
       - terraform/init:
@@ -131,9 +134,6 @@ jobs:
           backend_config_file: backends/<< parameters.environment >>.tfbackend
           var_file: config_<< parameters.environment >>.tfvars
           lock-timeout: 5m
-      - run:
-          name: Add curl
-          command: apk --no-cache add curl jq
       - slack/notify:
           channel: deployments
           event: fail

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+### Jira link
+
+
+### What?
+
+I have added/removed/altered:
+
+- [x] Added
+- [x] Removed
+- [x] Altered
+
+### Why?
+
+I am doing this because:
+
+-
+
+### AC
+
+- Tested
+- Shared with stakeholders
+- Pair reviewed


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Fixes deployment notifications

### Why?

I am doing this because:

- The event to trigger a failure bypasses the usual flow which would have installed curl and jq in the alpine image. This means we don't see failed deployment notifications. Hoisting the installation fixes this
