### PR TITLE
FPO-243 Add feedback url and api key form validation

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,6 @@
 export API_BASE_URL=http://localhost:5001
 export AWS_REGION=eu-west-2
-export PORT=5002
-export NODE_ENV=development
 export DELETION_ENABLED=true
+export FEEDBACK_URL=http://localhost:5002/
+export NODE_ENV=development
+export PORT=5002

--- a/src/app.ts
+++ b/src/app.ts
@@ -21,6 +21,7 @@ const app: Express = express()
 
 const isDev = app.get('env') === 'development'
 const port = process.env.PORT ?? 8080
+const feedbackURL = process.env.FEEDBACK_URL ?? ''
 
 const templateConfig: nunjucks.ConfigureOptions = {
   autoescape: true,
@@ -48,6 +49,8 @@ if (isDev) {
 
   nunjucksConfiguration.addGlobal('baseURL', scpConfiguration.baseURL)
 }
+
+nunjucksConfiguration.addGlobal('feedbackURL', feedbackURL)
 
 app.set('view engine', 'njk')
 

--- a/src/controllers/keyController.ts
+++ b/src/controllers/keyController.ts
@@ -19,10 +19,13 @@ export const create = async (req: Request, res: Response): Promise<void> => {
   const apiKeyDescription = req.body.apiKeyDescription as string
 
   try {
-    const apiKey = await ApiService.createAPIKey(organisationId, apiKeyDescription)
-    const secretHtml = ApiKeyPresenter.secretHtml(apiKey.Secret)
-
-    res.render('keySuccessPage', { secretHtml, organisationId })
+    if (apiKeyDescription === '') {
+      res.render('newKey', { organisationId })
+    } else {
+      const apiKey = await ApiService.createAPIKey(organisationId, apiKeyDescription)
+      const secretHtml = ApiKeyPresenter.secretHtml(apiKey.Secret)
+      res.render('keySuccessPage', { secretHtml, organisationId })
+    }
   } catch (error) {
     logger.error('Error showing create page', error)
     res.status(500).send('Error showing new key page')

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -50,6 +50,7 @@ Terraform to deploy the service into AWS.
 | <a name="input_deletion_enabled"></a> [deletion\_enabled](#input\_deletion\_enabled) | Sets DELETION\_ENABLED and determines whether to enable deletion of keys in the hub UI. | `bool` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |
+| <a name="input_feedback_url"></a> [feedback\_url](#input\_feedback\_url) | Feedback URL. | `string` | n/a | yes |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Largest number of tasks the service can scale-out to. | `number` | n/a | yes |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory to allocate in MB. Powers of 2 only. | `number` | n/a | yes |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | Smallest number of tasks the service can scale-in to. | `number` | n/a | yes |

--- a/terraform/config_development.tfvars
+++ b/terraform/config_development.tfvars
@@ -8,3 +8,4 @@ min_capacity                = 1
 max_capacity                = 3
 scp_open_id_issuer_base_url = "https://api.ete.access.service.gov.uk"
 deletion_enabled            = true
+feedback_url                = "https://dev.trade-tariff.service.gov.uk/feedback"

--- a/terraform/config_production.tfvars
+++ b/terraform/config_production.tfvars
@@ -8,3 +8,4 @@ min_capacity                = 2
 max_capacity                = 5
 scp_open_id_issuer_base_url = "https://api.access.service.gov.uk"
 deletion_enabled            = false
+feedback_url                = "https://www.trade-tariff.service.gov.uk/feedback"

--- a/terraform/config_staging.tfvars
+++ b/terraform/config_staging.tfvars
@@ -8,3 +8,4 @@ min_capacity                = 2
 max_capacity                = 5
 scp_open_id_issuer_base_url = "https://api.ete.access.service.gov.uk"
 deletion_enabled            = true
+feedback_url                = "https://staging.trade-tariff.service.gov.uk/feedback"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -70,7 +70,11 @@ module "service" {
     {
       name  = "DELETION_ENABLED"
       value = var.deletion_enabled
-    }
+    },
+    {
+      name  = "FEEDBACK_URL"
+      value = var.feedback_url
+    },
   ]
 
   service_secrets_config = [

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -52,3 +52,8 @@ variable "deletion_enabled" {
   description = "Sets DELETION_ENABLED and determines whether to enable deletion of keys in the hub UI."
   type        = bool
 }
+
+variable "feedback_url" {
+  description = "Feedback URL."
+  type        = string
+}

--- a/views/layout.html
+++ b/views/layout.html
@@ -55,7 +55,7 @@
         BETA
       </strong>
       <span class="govuk-phase-banner__text">
-        This is a new service – your <a class="govuk-link" href="/feedback">feedback</a> will help us to improve it.
+        This is a new service – your <a class="govuk-link" href="{{feedbackURL}}">feedback</a> will help us to improve it.
       </span>
     </p>
     <p>

--- a/views/newKey.html
+++ b/views/newKey.html
@@ -18,13 +18,20 @@
         text: "Text explaining good example of API key description."
       },
       id: "description",
-      name: "apiKeyDescription"
+      name: "apiKeyDescription",
+      errorMessage: {
+        text: "Enter the description for your API key"
+      }
     }) }}
+    <div class="govuk-button-group">
+      {{ govukButton({
+        text: "Continue",
+        type: "submit"
 
-    {{ govukButton({
-      text: "Continue",
-      type: "submit"
-    }) }}
+      }) }}
+      <a class="govuk-link" href="/dashboard/{{ organisationId }}">Cancel</a>
+    </div>
+
   </form>
 
   <p class="govuk-body">


### PR DESCRIPTION
### Jira link
[FPO-243](https://transformuk.atlassian.net/browse/FPO-243)
### What?

I have added/removed/altered:

- [x] Added a feedback url env variable 
- [x] Removed
- [x] Altered the description of the api key should not be empty

### Why?

I am doing this because:

- we need to be able to display different feedback url for each env
- prevent creating a key with an empty description

### AC

- Tested
- Shared with stakeholders
- Pair reviewed
