### PR TITLE
BAU: Tidy up broken release notes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,16 +170,6 @@ jobs:
           event: pass
           template: basic_success_1
 
-  notify-production-deployment:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - checkout
-      - tariff/notify-production-release:
-          app-name: FPO Developer Hub Backend
-          slack-channel: trade_tariff
-          release-tag: $CIRCLE_TAG
-
 workflows:
   version: 2
 
@@ -315,10 +305,3 @@ workflows:
           requires:
             - write-docker-tag-prod-release
           <<: *filter-release
-
-      # TODO: Work out why notifications produce failing parser errors (is this a JQ issue)
-      # - notify-production-deployment:
-      #     context: trade-tariff-releases
-      #     requires:
-      #       - apply-terraform-prod
-      #     <<: *filter-release


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Tidy up broken release notes

### Why?

I am doing this because:

- These fail and duplicate the other release notes we generate
