### PR TITLE
BAU: Add missing SecretsManager permission

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -27,11 +27,12 @@ data "aws_iam_policy_document" "exec" {
       data.aws_secretsmanager_secret.application_support_email.arn,
       data.aws_secretsmanager_secret.cognito_client_id.arn,
       data.aws_secretsmanager_secret.cognito_client_secret.arn,
+      data.aws_secretsmanager_secret.cookie_signing_secret.arn,
+      data.aws_secretsmanager_secret.csrf_signing_secret.arn,
       data.aws_secretsmanager_secret.govuk_notify_api_key.arn,
       data.aws_secretsmanager_secret.scp_open_id_client_id.arn,
       data.aws_secretsmanager_secret.scp_open_id_client_secret.arn,
       data.aws_secretsmanager_secret.scp_open_id_secret.arn,
-      data.aws_secretsmanager_secret.cookie_signing_secret.arn,
     ]
   }
 }


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Added missing SecretsManager IAM permission for CSRF signing secret.

### Why?

I am doing this because:

- The service is failing to deploy and rolling back because this is missing.