### PR TITLE
FPO-396: Adding a banner to warn the user if they are signing up with…

### DIFF
--- a/src/config/main-navigation-options.ts
+++ b/src/config/main-navigation-options.ts
@@ -18,21 +18,26 @@ export default function (req: any, res: Response, next: NextFunction): void {
 
     if (profileUrl != null) {
       profileUrl = profileUrl + '?redirect_uri=' + encodeURIComponent(baseUrl + '/auth/profile-redirect')
+
+      mainNavigation.push({
+        href: profileUrl,
+        text: 'Update Profile'
+      })
     }
 
     if (groupUrl != null) {
       groupUrl = groupUrl + '?redirect_uri=' + encodeURIComponent(baseUrl + '/auth/group-redirect')
-    }
-    logger.debug(`scpConfigBaseURL: ${baseUrl} for userProfile: ${profileUrl} and groupUrl: ${groupUrl}`)
 
-    mainNavigation.push({
-      href: profileUrl,
-      text: 'Update Profile'
-    })
-    mainNavigation.push({
-      href: groupUrl,
-      text: 'Manage Team'
-    })
+      mainNavigation.push({
+        href: groupUrl,
+        text: 'Manage Team'
+      })
+
+      res.locals.isOrgAccount = true
+    } else {
+      res.locals.isOrgAccount = false
+    }
+
     mainNavigation.push({
       href: '/logout',
       text: 'Sign Out'

--- a/views/verification.njk
+++ b/views/verification.njk
@@ -27,7 +27,7 @@
                     errorList: errorList
                 }) }}
             {% endif %}
-            <span class="govuk-caption-l">Register for the Commodity Code Identification Tool Developer Hub</span>
+            <span class="govuk-caption-l">Register for the Commodity Code Identification Tool</span>
             <h1 class="govuk-label govuk-label--l">Enter details about your organisation</h1>
             <p class="govuk-body">Enter the following information about your organisation. This will be used to verify your account.</p>
             <form method="POST" action="/check-verification">

--- a/views/verification.njk
+++ b/views/verification.njk
@@ -1,17 +1,33 @@
 {% extends "layout.njk" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
 
 {% block content %}
+
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
+            {% if not isOrgAccount %}
+                {% set bannerHtml %}
+                    <h3 class="govuk-notification-banner__heading">
+                        It looks like you're using a personal Government Gateway account
+                    </h3>
+                    <p class="govuk-body">If you register using this account you won't be able to invite other users to manage the API keys for this organisation.</p>
+                    <p class="govuk-body">You can <a class="govuk-notification-banner__link" href="#">sign out</a> and create a new Government Gateway account, or use an existing one, for your organisation.</p>
+                {% endset %}
+
+                {{ govukNotificationBanner({
+                    html: bannerHtml
+                }) }}
+            {% endif %}
             {% if errorList.length > 0 %}
                 {{ govukErrorSummary({
                     titleText: "There is a problem",
                     errorList: errorList
                 }) }}
             {% endif %}
-            <span class="govuk-caption-l">Commodity Code Identification Tool Developer Hub</span>
+            <span class="govuk-caption-l">Register for the Commodity Code Identification Tool Developer Hub</span>
             <h1 class="govuk-label govuk-label--l">Enter details about your organisation</h1>
             <p class="govuk-body">Enter the following information about your organisation. This will be used to verify your account.</p>
             <form method="POST" action="/check-verification">


### PR DESCRIPTION
… an individual gov gateway account

### Jira link
FPO-396

### What?

I have added/removed/altered:

- [x] Added a banner if the user is registering with an individual (rather than organisational) gov gateway account

### Why?

I am doing this because:

- If a user uses their personal account and they're in an organisation then they won't be able to add more team members.

### AC

- Tested
- Shared with stakeholders
- Pair reviewed
