### PR TITLE
BAU: Fixes csrf implicit verification on delete page

### DIFF
--- a/src/controllers/deleteController.ts
+++ b/src/controllers/deleteController.ts
@@ -2,6 +2,7 @@ import { type NextFunction, type Request, type Response } from 'express'
 import { ApiService } from '../services/apiService'
 import { CommonService } from '../services/commonService'
 import { DashboardPresenter } from '../presenters/dashboardPresenter'
+import { generateToken } from '../config/csrf'
 
 export const showDeleteKey = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
@@ -9,8 +10,9 @@ export const showDeleteKey = async (req: Request, res: Response, next: NextFunct
     const customerKeyId = req.params.customerKeyId
     const apiKey = await ApiService.getKey(user, customerKeyId)
     const createdAt = DashboardPresenter.formatDate(apiKey.CreatedAt, true)
+    const csrfToken = generateToken(req, res)
 
-    res.render('delete', { apiKey, createdAt, backLinkHref: '/dashboard' })
+    res.render('delete', { apiKey, csrfToken, createdAt, backLinkHref: '/dashboard' })
   } catch (error) {
     next(error)
   }

--- a/views/delete.njk
+++ b/views/delete.njk
@@ -30,6 +30,7 @@
             </table>
             <form method="POST"
                 action="/dashboard/{{ apiKey.CustomerApiKeyId }}/delete">
+                <input type="hidden" name="_csrf" value="{{csrfToken}}">
                 <div class="govuk-button-group">
                     <button class="govuk-button govuk-button--warning" data-module="govuk-button">Delete</button>
                     <a href="/dashboard" class="govuk-link">Cancel</a>


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added csrf token input on the delete page

### Why?

I am doing this because:

- This enables verification of this token as part of our security policy for this page
- It prevents an error where the verification fails thus blocking deletions

### AC

- Tested
- Shared with stakeholders
- Pair reviewed
